### PR TITLE
Remove (wrong) text property, not needed with blocks

### DIFF
--- a/server/src/api/services/clink/interactive/block_actions.ts
+++ b/server/src/api/services/clink/interactive/block_actions.ts
@@ -19,7 +19,6 @@ export async function handleBlockActions(payload: ISlackInteractionBlockActions)
                             json: {
                                 delete_original: true,
                                 response_type: 'in_channel',
-                                text: quote,
                                 blocks: buildQuoteSection(quote),
                             },
                         });
@@ -220,7 +219,6 @@ export async function handleBlockActions(payload: ISlackInteractionBlockActions)
                                     json: {
                                         delete_original: true,
                                         response_type: 'in_channel',
-                                        text: quote,
                                         blocks: buildQuoteSection(quote),
                                     },
                                 });


### PR DESCRIPTION
Slack must have ignored this being bad in the past